### PR TITLE
Add EX3_RETHROW

### DIFF
--- a/exceptions.hpp
+++ b/exceptions.hpp
@@ -47,6 +47,13 @@
 
 #endif
 
+/**
+ * @brief Macro for rethrowing an exception.
+ *
+ */
+#define EX3_RETHROW(ExeptInstance) \
+    BOOST_THROW_EXCEPTION(ExeptInstance)
+
 namespace ex3 {
 
 #if !defined(EX3_NO_STACKTRACE)


### PR DESCRIPTION
Add a rethrow macro so stack trace won't be rewritten when adding more information to the original exception.